### PR TITLE
添加《Nginx教程从入门到精通》

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 ### WEB服务器
 
 * [Nginx开发从入门到精通](http://tengine.taobao.org/book/index.html) (淘宝团队出品)
+* [Nginx教程从入门到精通](http://www.ttlsa.com/nginx/nginx-stu-pdf/)(PDF版本，运维生存时间出品)
 * [Apache 中文手册](http://works.jinbuguo.com/apache/menu22/index.html)
 
 ### 版本控制


### PR DESCRIPTION
这本跟淘宝团队的《Nginx开发从入门到精通》不是同一本。前者偏重如何使用，后者偏重背后原理。