### PR TITLE
添加一级分类:函数式概念，添加语言相关:RW Ocaml的翻译版

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   * [智能系统](#智能系统)
   * [分布式系统](#分布式系统)
   * [编译原理](#编译原理)
+  * [函数式概念](#函数式概念)
   * [计算机图形学](#计算机图形学)
   * [WEB服务器](#web服务器)
   * [版本控制](#版本控制)
@@ -56,6 +57,7 @@
   * [LaTeX](#latex)
   * [LISP](#lisp)
   * [Lua](#lua)
+  * [OCaml](#OCaml)
   * [Perl](#perl)
   * [PHP](#php)
   * [Prolog](#prolog)
@@ -103,6 +105,9 @@
 
 ### 编译原理
 * [《计算机程序的结构和解释》公开课 翻译项目](https://github.com/DeathKing/Learning-SICP)
+
+### 函数式概念
+* [傻瓜函数编程](https://github.com/justinyhuang/Functional-Programming-For-The-Rest-of-Us-Cn)
 
 ### 计算机图形学
 * [OpenGL 教程](https://github.com/zilongshanren/opengl-tutorials)
@@ -448,6 +453,10 @@
 * [Lua源码欣赏](http://www.codingnow.com/temp/readinglua.pdf)
 * [lua程序设计](http://book.luaer.cn/)
 
+### OCaml
+
+* [Real World OCaml](https://github.com/zforget/translation/tree/master/real_world_ocaml)
+
 ### Perl
 
 * [Modern Perl 中文版](https://github.com/horus/modern_perl_book)
@@ -546,7 +555,7 @@
 
 ### Rust
 
-* [rust book 中文翻译](https://www.gitbook.com/book/kaisery/rust-book-chinese/details) 
+* [rust book 中文翻译](https://www.gitbook.com/book/kaisery/rust-book-chinese/details)
 
 ### Scala
 


### PR DESCRIPTION
1、函数式概念可以作为一个一级分类，学习PLT之前最好有一个系列的扫盲文章，傻瓜函数式这篇翻译讲解函数式特性的方式比较易懂，适合新手；相关的基本概念还有范式讲解等，不过文章一时没找到，后续我会继续补充。
2、学习类型系统需要了解点OCaml，比如Pierce的Types and Programming Languages，这本real world虽然没有翻译完、但是ML基础都讲到了，模式匹配，ADT、

