### PR TITLE
添加前端开发笔记本

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@
 * [借助开源项目，学习软件开发](https://github.com/zhuangbiaowei/learn-with-open-source)
 * [前端工作面试问题](https://github.com/h5bp/Front-end-Developer-Interview-Questions/tree/master/Translations/Chinese)
 * [leetcode/lintcode题解/算法学习笔记](https://www.gitbook.com/book/yuanbin/algorithm/details)
+* [前端开发笔记本](https://github.com/li-xinyang/FEND_Note)
 
 ### 测试相关
 


### PR DESCRIPTION
前端笔记本涵盖了 Web 前端开发所需的基本知识以及学习路径。它并不能当做一本完整的学习材料，因为在有限的篇幅中无法深入的展开每一个知识点。它更适合作为一个学习清单或者是查询手册，结合其他更在各个方面更专业的图书或者官方文档来进行同步学习。在使用过程中为了达到最佳的学习效果，也因将每个技术点实现并进行适当的拓展。