### PR TITLE
Repair CorePython_zh link

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@
 * [Python 学习笔记 模块篇](http://www.kuqin.com/docs/pythonmodule.html)
 * [Python 标准库 中文版](http://old.sebug.net/paper/books/python/%E3%80%8APython%E6%A0%87%E5%87%86%E5%BA%93%E3%80%8B%E4%B8%AD%E6%96%87%E7%89%88.pdf)
 * [Python进阶](https://www.gitbook.com/book/eastlakeside/interpy-zh/details)
-* [Python 核心编程 第二版](http://openbookproject.googlecode.com/svn/trunk/CorePython_zh/) CPyUG译
+* [Python 核心编程 第二版](https://wizardforcel.gitbooks.io/core-python-2e/content/) CPyUG译
 * [Python最佳实践指南](http://pythonguidecn.readthedocs.io/zh/latest/)
 * Django
     * [Django 1.5 文档中文版](http://django-chinese-docs.readthedocs.org/en/latest/) 正在翻译中


### PR DESCRIPTION
Python核心编程的googlecode的链接失效, 切换至gitbook