### PR TITLE
clojure入门教程(gitbook)链接更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@
 
 ### Clojure
 
-* [Clojure入门教程](http://xumingming.sinaapp.com/302/clojure-functional-programming-for-the-jvm-clojure-tutorial/)
+* [Clojure入门教程](https://wizardforcel.gitbooks.io/clojure-fpftj/content/index.html)
 
 <h3 id="csshtml">CSS/HTML</h3>
 
@@ -721,5 +721,3 @@
 ### 测试相关
 
 * [移动APP自动化测试优秀框架Appium API Reference V1.2.0 CN](http://appium.io/slate/cn/v1.2.0/)
-
-


### PR DESCRIPTION
clojure入门教程的链接失效了。
补上gitbook版本的链接。
