### PR TITLE
fix link: Clojure/Clojure入门教程

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@
 
 ## Clojure
 
-* [Clojure入门教程](http://xumingming.sinaapp.com/302/clojure-functional-programming-for-the-jvm-clojure-tutorial/)
+* [Clojure入门教程](https://wizardforcel.gitbooks.io/clojure-fpftj/)
 
 [返回目录](#目录)
 


### PR DESCRIPTION
原链接 http://xumingming.sinaapp.com/302/clojure-functional-programming-for-the-jvm-clojure-tutorial/
新链接 https://wizardforcel.gitbooks.io/clojure-fpftj/
新链接来自于一个翻译与搬运大佬的书库，未知是否已得到原作者授权。