### PR TITLE
标注失效链接 :worried:

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@
 * [The Linux Command Line](http://billie66.github.io/TLCL/index.html) (中英文版)
 * [Linux 设备驱动](http://oss.org.cn/kernel-book/ldd3/index.html) (第三版):worried:
 * [深入分析Linux内核源码](http://www.kerneltravel.net/kernel-book/%E6%B7%B1%E5%85%A5%E5%88%86%E6%9E%90Linux%E5%86%85%E6%A0%B8%E6%BA%90%E7%A0%81.html) :worried:
-* [UNIX TOOLBOX](http://cb.vu/unixtoolbox_zh_CN.xhtml)
+* [UNIX TOOLBOX](http://cb.vu/unixtoolbox_zh_CN.xhtml) :worried:
 * [Docker中文指南](https://github.com/widuu/chinese_docker)
 * [Docker —— 从入门到实践](https://github.com/yeasy/docker_practice)
-* [Docker入门实战](http://yuedu.baidu.com/ebook/d817967416fc700abb68fca1)
+* [Docker入门实战](http://yuedu.baidu.com/ebook/d817967416fc700abb68fca1) :worried:
 * [Docker Cheat Sheet](https://github.com/wsargent/docker-cheat-sheet/tree/master/zh-cn#docker-cheat-sheet)
 * [FreeRADIUS新手入门](http://freeradius.akagi201.org) :worried:
 * [Mac 开发配置手册](https://aaaaaashu.gitbooks.io/mac-dev-setup/content/)
@@ -108,8 +108,8 @@
 * [Linux 命令行(中文版)](http://billie66.github.io/TLCL/book/)
 * [Linux 构建指南](http://works.jinbuguo.com/lfs/lfs62/index.html)
 * [Linux工具快速教程](https://github.com/me115/linuxtools_rst)
-* [Linux Documentation (中文版)](https://www.gitbook.com/book/tinylab/linux-doc/details)
-* [嵌入式 Linux 知识库 (eLinux.org 中文版)](https://www.gitbook.com/book/tinylab/elinux/details)
+* [Linux Documentation (中文版)](https://www.gitbook.com/book/tinylab/linux-doc/details) :worried:
+* [嵌入式 Linux 知识库 (eLinux.org 中文版)](https://www.gitbook.com/book/tinylab/elinux/details) :worried:
 * [理解Linux进程](https://github.com/tobegit3hub/understand_linux_process)
 * [命令行的艺术](https://github.com/jlevy/the-art-of-command-line/blob/master/README-zh.md)
 * [SystemTap新手指南](https://spacewander.gitbooks.io/systemtapbeginnersguide_zh/content/index.html)
@@ -148,7 +148,7 @@
 
 * [Nginx开发从入门到精通](http://tengine.taobao.org/book/index.html) (淘宝团队出品)
 * [Nginx教程从入门到精通](http://www.ttlsa.com/nginx/nginx-stu-pdf/)(PDF版本，运维生存时间出品)
-* [OpenResty最佳实践](https://www.gitbook.com/book/moonbingbing/openresty-best-practices/details)
+* [OpenResty最佳实践](https://www.gitbook.com/book/moonbingbing/openresty-best-practices/details) :worried:
 * [Apache 中文手册](http://works.jinbuguo.com/apache/menu22/index.html)
 
 [返回目录](#目录)
@@ -162,14 +162,14 @@
 * [猴子都能懂的GIT入门](http://backlogtool.com/git-guide/cn/)
 * [Git 参考手册](http://gitref.justjavac.com)
 * [Pro Git](http://git-scm.com/book/zh/v2)
-* [Pro Git 中文版](https://www.gitbook.com/book/0532/progit/details) (整理在gitbook上)
+* [Pro Git 中文版](https://www.gitbook.com/book/0532/progit/details) (整理在gitbook上) :worried:
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/zh_cn/)
 * [GotGitHub](http://www.worldhello.net/gotgithub/index.html)
 * [Git权威指南](http://www.worldhello.net/gotgit/)
 * [Git Community Book 中文版](http://gitbook.liuhui998.com/index.html)
 * [Mercurial 使用教程](https://www.mercurial-scm.org/wiki/ChineseTutorial)
-* [HgInit (中文版)](http://bucunzai.net/hginit/)
-* [沉浸式学 Git](http://igit.linuxtoy.org)
+* [HgInit (中文版)](http://bucunzai.net/hginit/) :worried:
+* [沉浸式学 Git](http://igit.linuxtoy.org) :worried:
 * [Git-Cheat-Sheet](https://github.com/flyhigher139/Git-Cheat-Sheet) （感谢 @flyhigher139 翻译了中文版）
 * [GitHub秘籍](https://snowdream86.gitbooks.io/github-cheat-sheet/content/zh/index.html)
 * [GitHub帮助文档](https://github.com/waylau/github-help)
@@ -198,16 +198,16 @@
 
 ## NoSQL
 
-* [NoSQL数据库笔谈](http://old.sebug.net/paper/databases/nosql/Nosql.html)
+* [NoSQL数据库笔谈](http://old.sebug.net/paper/databases/nosql/Nosql.html) :worried:
 * [Redis 设计与实现](http://redisbook.com/)
-* [Redis 命令参考](http://redisdoc.com/)
+* [Redis 命令参考](http://redisdoc.com/) :worried:
 * [带有详细注释的 Redis 3.0 代码](https://github.com/huangz1990/redis-3.0-annotated)
 * [带有详细注释的 Redis 2.6 代码](https://github.com/huangz1990/annotated_redis_source)
 * [The Little MongoDB Book](https://github.com/justinyhuang/the-little-mongodb-book-cn/blob/master/mongodb.md)
 * [The Little Redis Book](https://github.com/JasonLai256/the-little-redis-book/blob/master/cn/redis.md)
-* [Neo4j 简体中文手册 v1.8](http://docs.neo4j.org.cn/)
+* [Neo4j 简体中文手册 v1.8](http://docs.neo4j.org.cn/) :worried:
 * [Neo4j .rb 中文資源](http://neo4j.tw/)
-* [Disque 使用教程](http://disquebook.com)
+* [Disque 使用教程](http://disquebook.com) :worried:
 * [Apache Spark 设计与实现](https://github.com/JerryLead/SparkInternals/tree/master/markdown)
 
 [返回目录](#目录)
@@ -229,31 +229,31 @@
 
 ## 管理和监控
 
-* [ELKstack 中文指南](http://kibana.logstash.es)
-* [Mastering Elasticsearch(中文版)](http://udn.yyuap.com/doc/mastering-elasticsearch/)
-* [ElasticSearch 权威指南](https://www.gitbook.com/book/fuxiaopang/learnelasticsearch/details)
-* [Elasticsearch 权威指南（中文版）](http://es.xiaoleilu.com)
+* [ELKstack 中文指南](http://kibana.logstash.es) :worried:
+* [Mastering Elasticsearch(中文版)](http://udn.yyuap.com/doc/mastering-elasticsearch/) :worried:
+* [ElasticSearch 权威指南](https://www.gitbook.com/book/fuxiaopang/learnelasticsearch/details) :worried:
+* [Elasticsearch 权威指南（中文版）](http://es.xiaoleilu.com) :worried:
 * [Logstash 最佳实践](https://github.com/chenryn/logstash-best-practice-cn)
-* [Puppet 2.7 Cookbook 中文版](http://bbs.konotes.org/workdoc/puppet-27/)
+* [Puppet 2.7 Cookbook 中文版](http://bbs.konotes.org/workdoc/puppet-27/) :worried:
 
 [返回目录](#目录)
 
 ## 项目相关
 
-* [持续集成（第二版）](http://article.yeeyan.org/view/2251/94882) (译言网)
+* [持续集成（第二版）](http://article.yeeyan.org/view/2251/94882) (译言网) :worried:
 * [让开发自动化系列专栏](http://www.ibm.com/developerworks/cn/java/j-ap/)
 * [追求代码质量](http://www.ibm.com/developerworks/cn/java/j-cq/)
-* [selenium 中文文档](https://github.com/fool2fish/selenium-doc)
+* [selenium 中文文档](https://github.com/fool2fish/selenium-doc) :worried:
 * [Selenium Webdriver 简易教程](http://it-ebooks.flygon.net/selenium-simple-tutorial/)
-* [Joel谈软件](http://local.joelonsoftware.com/wiki/Chinese_\(Simplified\))
-* [約耳談軟體(Joel on Software)](http://local.joelonsoftware.com/wiki/%E9%A6%96%E9%A0%81)
+* [Joel谈软件](http://local.joelonsoftware.com/wiki/Chinese_\(Simplified\)) :worried:
+* [約耳談軟體(Joel on Software)](http://local.joelonsoftware.com/wiki/%E9%A6%96%E9%A0%81) :worried:
 * [Gradle 2 用户指南](https://github.com/waylau/Gradle-2-User-Guide)
-* [Gradle 中文使用文档](http://yuedu.baidu.com/ebook/f23af265998fcc22bcd10da2)
+* [Gradle 中文使用文档](http://yuedu.baidu.com/ebook/f23af265998fcc22bcd10da2) :worried:
 * [编码规范](https://github.com/ecomfe/spec)
 * [开源软件架构](http://www.ituring.com.cn/book/1143)
 * [GNU make 指南](http://docs.huihoo.com/gnu/linux/gmake.html)
-* [GNU make 中文手册](http://www.yayu.org/book/gnu_make/)
-* [The Twelve-Factor App](http://12factor.net/zh_cn/)
+* [GNU make 中文手册](http://www.yayu.org/book/gnu_make/) :worried:
+* [The Twelve-Factor App](http://12factor.net/zh_cn/) :worried:
 
 [返回目录](#目录)
 
@@ -262,13 +262,13 @@
 * [图说设计模式](https://github.com/me115/design_patterns)
 * [史上最全设计模式导学目录](http://blog.csdn.net/lovelion/article/details/17517213)
 * [design pattern 包教不包会](https://github.com/AlfredTheBest/Design-Pattern)
-* [设计模式 Java 版](https://quanke.gitbooks.io/design-pattern-java/content/)
+* [设计模式 Java 版](https://quanke.gitbooks.io/design-pattern-java/content/) :worried:
 
 [返回目录](#目录)
 
 ## Web
 
-* [关于浏览器和网络的 20 项须知](http://www.20thingsilearned.com/zh-CN/home)
+* [关于浏览器和网络的 20 项须知](http://www.20thingsilearned.com/zh-CN/home) :worried:
 * [浏览器开发工具的秘密](http://jinlong.github.io/2013/08/29/devtoolsecrets/)
 * [Chrome 开发者工具中文手册](https://github.com/CN-Chrome-DevTools/CN-Chrome-DevTools)
 * [Chrome扩展开发文档](http://open.chrome.360.cn/extension_dev/overview.html)
@@ -284,17 +284,17 @@
 * [前端资源分享（一）](https://github.com/hacke2/hacke2.github.io/issues/1)
 * [前端资源分享（二）](https://github.com/hacke2/hacke2.github.io/issues/3)
 * [前端代码规范 及 最佳实践](http://coderlmn.github.io/code-standards/)
-* [前端开发者手册](https://www.gitbook.com/book/dwqs/frontenddevhandbook/details)
-* [前端工程师手册](https://www.gitbook.com/book/leohxj/front-end-database/details)
-* [w3school教程整理](https://github.com/wizardforcel/w3school)
-* [Wireshark用户手册](http://man.lupaworld.com/content/network/wireshark/index.html)
-* [一站式学习Wireshark](https://community.emc.com/thread/194901)
+* [前端开发者手册](https://www.gitbook.com/book/dwqs/frontenddevhandbook/details) :worried:
+* [前端工程师手册](https://www.gitbook.com/book/leohxj/front-end-database/details) :worried:
+* [w3school教程整理](https://github.com/wizardforcel/w3school) :worried:
+* [Wireshark用户手册](http://man.lupaworld.com/content/network/wireshark/index.html) :worried:
+* [一站式学习Wireshark](https://community.emc.com/thread/194901) :worried:
 * [HTTP 下午茶](https://ccbikai.gitbooks.io/http-book/content/)
-* [HTTP/2.0 中文翻译](http://yuedu.baidu.com/ebook/478d1a62376baf1ffc4fad99?pn=1)
+* [HTTP/2.0 中文翻译](http://yuedu.baidu.com/ebook/478d1a62376baf1ffc4fad99?pn=1) :worried:
 * [RFC 7540 - HTTP/2 中文翻译版](https://github.com/abbshr/rfc7540-translation-zh_cn)
-* [http2讲解](https://www.gitbook.com/book/ye11ow/http2-explained/details)
-* [3 Web Designs in 3 Weeks](https://www.gitbook.com/book/juntao/3-web-designs-in-3-weeks/details)
-* [站点可靠性工程](https://github.com/hellorocky/Site-Reliability-Engineering)
+* [http2讲解](https://www.gitbook.com/book/ye11ow/http2-explained/details) :worried:
+* [3 Web Designs in 3 Weeks](https://www.gitbook.com/book/juntao/3-web-designs-in-3-weeks/details) :worried:
+* [站点可靠性工程](https://github.com/hellorocky/Site-Reliability-Engineering) :worried:
 * [Web安全学习笔记](https://websec.readthedocs.io)
 * [Serverless 架构应用开发指南](https://github.com/phodal/serverless)
 
@@ -302,9 +302,9 @@
 
 ## 大数据
 
-* [大数据/数据挖掘/推荐系统/机器学习相关资源](https://github.com/Flowerowl/Big-Data-Resources)
-* [面向程序员的数据挖掘指南](https://github.com/egrcc/guidetodatamining)
-* [大型集群上的快速和通用数据处理架构](https://code.csdn.net/CODE_Translation/spark_matei_phd)
+* [大数据/数据挖掘/推荐系统/机器学习相关资源](https://github.com/Flowerowl/Big-Data-Resources) :worried:
+* [面向程序员的数据挖掘指南](https://github.com/egrcc/guidetodatamining) :worried:
+* [大型集群上的快速和通用数据处理架构](https://code.csdn.net/CODE_Translation/spark_matei_phd) :worried:
 * [数据挖掘中经典的算法实现和详细的注释](https://github.com/linyiqun/DataMiningAlgorithm)
 * [Spark 编程指南简体中文版](https://aiyanbo.gitbooks.io/spark-programming-guide-zh-cn/content/)
 
@@ -314,7 +314,7 @@
 
 * [程序员编程艺术](https://github.com/julycoding/The-Art-Of-Programming-by-July)
 * [每个程序员都应该了解的内存知识(译)](http://www.oschina.net/translate/what-every-programmer-should-know-about-memory-part1?print)【第一部分】
-* [取悦的工序：如何理解游戏](http://read.douban.com/ebook/4972883/) (豆瓣阅读，免费书籍)
+* [取悦的工序：如何理解游戏](http://read.douban.com/ebook/4972883/) (豆瓣阅读，免费书籍) :worried:
 
 [返回目录](#目录)
 
@@ -332,8 +332,8 @@
 
 ## 其它
 
-* [OpenWrt智能、自动、透明翻墙路由器教程](https://www.gitbook.com/book/softwaredownload/openwrt-fanqiang/details)
-* [SAN 管理入门系列](https://community.emc.com/docs/DOC-16067)
+* [OpenWrt智能、自动、透明翻墙路由器教程](https://www.gitbook.com/book/softwaredownload/openwrt-fanqiang/details) :worried:
+* [SAN 管理入门系列](https://community.emc.com/docs/DOC-16067) :worried:
 * [Sketch 中文手册](http://sketchcn.com/sketch-chinese-user-manual.html#introduce)
 * [深入理解并行编程](http://ifeve.com/perfbook/)
 * [程序员的自我修养](http://www.kancloud.cn/kancloud/a-programmer-prepares)
@@ -344,14 +344,14 @@
 
 ## Android
 
-* [Android Design(中文版)](http://www.apkbus.com/design/index.html)
+* [Android Design(中文版)](http://www.apkbus.com/design/index.html) :worried:
 * Google Material Design 正體中文版 ([译本一](https://wcc723.gitbooks.io/google_design_translate/content/style-icons.html) [译本二](https://github.com/1sters/material_design_zh))
 * [Material Design 中文版](http://wiki.jikexueyuan.com/project/material-design/)
 * [Google Android官方培训课程中文版](http://hukai.me/android-training-course-in-chinese/index.html)
-* [Android学习之路](http://www.stormzhang.com/android/2014/07/07/learn-android-from-rookie/)
+* [Android学习之路](http://www.stormzhang.com/android/2014/07/07/learn-android-from-rookie/) :worried:
 * [Android开发技术前线(android-tech-frontier)](https://github.com/bboyfeiyu/android-tech-frontier)
 * [Point-of-Android](https://github.com/FX-Max/Point-of-Android) Android 一些重要知识点解析整理
-* [Android6.0新特性详解](http://leanote.com/blog/post/561658f938f41126b2000298)
+* [Android6.0新特性详解](http://leanote.com/blog/post/561658f938f41126b2000298) :worried:
 
 [返回目录](#目录)
 
@@ -372,7 +372,7 @@
 ## C/C++
 
 * [C/C++ 中文参考手册](http://zh.cppreference.com/) (欢迎大家参与在线翻译和校对)
-* [C 语言编程透视](https://www.gitbook.com/book/tinylab/cbook/details)
+* [C 语言编程透视](https://www.gitbook.com/book/tinylab/cbook/details) :worried:
 * [C++ 并发编程指南](https://github.com/forhappy/Cplusplus-Concurrency-In-Practice)
 * [Linux C编程一站式学习](http://akaedu.github.io/book/) (宋劲杉, 北京亚嵌教育研究中心)
 * [CGDB中文手册](https://github.com/leeyiw/cgdb-manual-in-chinese)
@@ -385,11 +385,11 @@
 * [GNU make 指南](http://docs.huihoo.com/gnu/linux/gmake.html)
 * [Google C++ 风格指南](http://zh-google-styleguide.readthedocs.org/en/latest/google-cpp-styleguide/contents/)
 * [C/C++ Primer](https://github.com/andycai/cprimer) (by @andycai)
-* [简单易懂的C魔法](http://www.nowamagic.net/librarys/books/contents/c)
+* [简单易懂的C魔法](http://www.nowamagic.net/librarys/books/contents/c) :worried:
 * [C++ FAQ LITE(中文版)](http://www.sunistudio.com/cppfaq/)
 * [C++ Primer 5th Answers](https://github.com/Mooophy/Cpp-Primer)
-* [C++ 并发编程(基于C++11)](https://www.gitbook.com/book/chenxiaowei/cpp_concurrency_in_action/details)
-* [QT 教程](http://www.kuqin.com/qtdocument/tutorial.html)
+* [C++ 并发编程(基于C++11)](https://www.gitbook.com/book/chenxiaowei/cpp_concurrency_in_action/details) :worried:
+* [QT 教程](http://www.kuqin.com/qtdocument/tutorial.html) :worried:
 * [DevBean的《Qt学习之路2》(Qt5)](http://www.devbean.net/category/qt-study-road-2/)
 * [中文版《QmlBook》](https://github.com/cwc1987/QmlBook-In-Chinese)
 * [C++ Template 进阶指南](https://github.com/wuye9036/CppTemplateTutorial)
@@ -433,7 +433,7 @@
 
 ## Dart
 
-* [Dart 语言导览](http://dart.lidian.info/wiki/Language_Tour)
+* [Dart 语言导览](http://dart.lidian.info/wiki/Language_Tour) :worried:
 
 [返回目录](#目录)
 
@@ -445,7 +445,7 @@
 
 ## Erlang
 
-* [21天学通Erlang](http://xn--21erlang-p00o82pmp3o.github.io/)
+* [21天学通Erlang](http://xn--21erlang-p00o82pmp3o.github.io/) :worried:
 
 [返回目录](#目录)
 
@@ -463,10 +463,10 @@
 * [Go Web 编程](https://github.com/astaxie/build-web-application-with-golang) (此书已经出版，希望开发者们去购买，支持作者的创作)
 * [Go实战开发](https://github.com/astaxie/Go-in-Action) (当我收录此项目时，作者已经写完第三章，如果读完前面章节觉得有帮助，可以给作者[捐赠](https://me.alipay.com/astaxie)，以鼓励作者的继续创作)
 * [Network programming with Go 中文翻译版本](https://github.com/astaxie/NPWG_zh)
-* [Effective Go](http://www.hellogcc.org/effective_go.html)
+* [Effective Go](http://www.hellogcc.org/effective_go.html) :worried:
 * [Go 语言标准库](https://github.com/polaris1119/The-Golang-Standard-Library-by-Example)
-* [Golang标准库文档](http://godoc.ml/)
-* [Revel 框架手册](http://gorevel.cn/docs/manual/index.html)
+* [Golang标准库文档](http://godoc.ml/) :worried:
+* [Revel 框架手册](http://gorevel.cn/docs/manual/index.html) :worried:
 * [Java程序员的Golang入门指南](http://blog.csdn.net/dc_726/article/details/46565241)
 * [Go命令教程](https://github.com/hyper-carrot/go_command_tutorial)
 * [Go语言博客实践](https://github.com/achun/Go-Blog-In-Action)
@@ -478,7 +478,7 @@
 * [Golang 系列教程(译)](https://github.com/Tinywan/golang-tutorial)   
 * [Go RPC 开发指南](https://github.com/smallnest/go-rpc-programming-guide)[GitBook](https://smallnest.gitbooks.io/go-rpc-programming-guide/)
 * [Go语言高级编程](https://books.studygolang.com/advanced-go-programming-book/)   
-* [Go2编程指南](https://chai2010.cn/go2-book/)   
+* [Go2编程指南](https://chai2010.cn/go2-book/) :worried:
 * [Go语言设计模式](https://github.com/senghoo/golang-design-pattern)   
 * [Go语言四十二章经](https://github.com/ffhelicopter/Go42)   
 
@@ -486,24 +486,24 @@
 
 ## Groovy
 
-* [实战 Groovy 系列](http://www.ibm.com/developerworks/cn/java/j-pg/)
+* [实战 Groovy 系列](http://www.ibm.com/developerworks/cn/java/j-pg/) :worried:
 
 [返回目录](#目录)
 
 ## Haskell
 
 * [Real World Haskell 中文版](http://rwh.readthedocs.org/en/latest/)
-* [Haskell趣学指南](https://learnyoua.haskell.sg/content/zh-cn/)
+* [Haskell趣学指南](https://learnyoua.haskell.sg/content/zh-cn/) :worried:
 
 [返回目录](#目录)
 
 ## iOS
 
 * [iOS开发60分钟入门](https://github.com/qinjx/30min_guides/blob/master/ios.md)
-* [iOS7人机界面指南](http://isux.tencent.com/ios-human-interface-guidelines-ui-design-basics-ios7.html)
+* [iOS7人机界面指南](http://isux.tencent.com/ios-human-interface-guidelines-ui-design-basics-ios7.html) :worried:
 * [Google Objective-C Style Guide 中文版](http://zh-google-styleguide.readthedocs.org/en/latest/google-objc-styleguide/)
 * [iPhone 6 屏幕揭秘](http://wileam.com/iphone-6-screen-cn/)
-* [Apple Watch开发初探](http://nilsun.github.io/apple-watch/)
+* [Apple Watch开发初探](http://nilsun.github.io/apple-watch/) :worried:
 * [马上着手开发 iOS 应用程序](https://developer.apple.com/library/ios/referencelibrary/GettingStarted/RoadMapiOSCh/index.html)
 * [网易斯坦福大学公开课：iOS 7应用开发字幕文件](https://github.com/jkyin/Subtitle)
 
@@ -516,7 +516,7 @@
 * [Spring Framework 4.x参考文档](https://github.com/waylau/spring-framework-4-reference)
 * [Spring Boot参考指南](https://github.com/qibaoguang/Spring-Boot-Reference-Guide) (翻译中)
 * [MyBatis中文文档](http://mybatis.org/mybatis-3/zh/index.html)
-* [MyBatis Generator 中文文档](http://mbg.cndocs.tk/)
+* [MyBatis Generator 中文文档](http://mbg.cndocs.tk/) :worried:
 * [用jersey构建REST服务](https://github.com/waylau/RestDemo)
 * [Activiti 5.x 用户指南](https://github.com/waylau/activiti-5.x-user-guide)
 * [Google Java编程风格指南](https://hawstein.com/2014/01/20/google-java-style/)
@@ -530,7 +530,7 @@
 * [JSSE 参考指南](https://github.com/waylau/jsse-reference-guide)
 * [Java开源实现及最佳实践](https://github.com/biezhi/jb)
 * [Java 编程要点](https://github.com/waylau/essential-java)
-* [Think Java](http://www.ituring.com.cn/minibook/69)
+* [Think Java](http://www.ituring.com.cn/minibook/69) :worried:
 * [Java 8 简明教程](https://github.com/wizardforcel/modern-java-zh)
 * [On Java 8 中文版](https://github.com/LingCoder/OnJava8) (翻译中)
 * [Effective Java 第3版中文版](https://github.com/sjsdfg/effective-java-3rd-chinese) 
@@ -540,14 +540,14 @@
 ## JavaScript
 
 * [现代 Javascript 教程](https://zh.javascript.info/)
-* [Google JavaScript 代码风格指南](http://bq69.com/blog/articles/script/868/google-javascript-style-guide.html)
+* [Google JavaScript 代码风格指南](http://bq69.com/blog/articles/script/868/google-javascript-style-guide.html) :worried:
 * [Google JSON 风格指南](https://github.com/darcyliu/google-styleguide/blob/master/JSONStyleGuide.md)
 * [Airbnb JavaScript 规范](https://github.com/adamlu/javascript-style-guide)
 * [JavaScript 标准参考教程（alpha）](http://javascript.ruanyifeng.com/)
 * [Javascript编程指南](http://pij.robinqu.me/) ([源码](https://github.com/RobinQu/Programing-In-Javascript))
 * [javascript 的 12 个怪癖](https://github.com/justjavac/12-javascript-quirks)
-* [JavaScript 秘密花园](http://bonsaiden.github.io/JavaScript-Garden/zh/)
-* [JavaScript核心概念及实践](http://icodeit.org/jsccp/) (PDF) (此书已由人民邮电出版社出版发行，但作者依然免费提供PDF版本，希望开发者们去购买，支持作者)
+* [JavaScript 秘密花园](http://bonsaiden.github.io/JavaScript-Garden/zh/) :worried:
+* [JavaScript核心概念及实践](http://icodeit.org/jsccp/) (PDF) (此书已由人民邮电出版社出版发行，但作者依然免费提供PDF版本，希望开发者们去购买，支持作者) :worried:
 * [《JavaScript 模式》](https://github.com/jayli/javascript-patterns) “JavaScript patterns”中译本
 * [JavaScript语言精粹](https://github.com/qibaoguang/Study-Step-by-Step/blob/master/%E8%AF%BB%E4%B9%A6%E7%AC%94%E8%AE%B0/javascript_the_good_parts.md)
 * [命名函数表达式探秘](http://justjavac.com/named-function-expressions-demystified.html)  (注:原文由[为之漫笔](http://www.cn-cuckoo.com)翻译，原始地址无法打开，所以此处地址为我博客上的备份)
@@ -560,11 +560,11 @@
 * [JavaScript 教程](http://www.liaoxuefeng.com/wiki/001434446689867b27157e896e74d51a89c25cc8b43bdb3000) 廖雪峰
 * [MDN JavaScript 中文文档](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript)
 * jQuery
-    * [jQuery 解构](http://www.cn-cuckoo.com/deconstructed/jquery.html)
-    * [简单易懂的JQuery魔法](http://www.nowamagic.net/librarys/books/contents/jquery)
+    * [jQuery 解构](http://www.cn-cuckoo.com/deconstructed/jquery.html) :worried:
+    * [简单易懂的JQuery魔法](http://www.nowamagic.net/librarys/books/contents/jquery) :worried:
     * [How to write jQuery plugin](http://i5ting.github.io/How-to-write-jQuery-plugin/build/jquery.plugin.html)
     * [You Don't Need jQuery](https://github.com/oneuijs/You-Dont-Need-jQuery/blob/master/README.zh-CN.md)
-    * [如何实现一个类jQuery？](https://github.com/MeCKodo/forchange)
+    * [如何实现一个类jQuery？](https://github.com/MeCKodo/forchange) :worried:
 * Node.js
     * [Node入门](http://www.nodebeginner.org/index-zh-cn.html)
     * [七天学会NodeJS](http://nqdeng.github.io/7-days-nodejs/)
@@ -577,60 +577,60 @@
     * [Node.js 包教不包会](https://github.com/alsotang/node-lessons)
     * [Learn You The Node.js For Much Win! (中文版)](https://www.npmjs.com/package/learnyounode-zh-cn)
     * [Node debug 三法三例](http://i5ting.github.io/node-debug-tutorial/)
-    * [nodejs中文文档](https://www.gitbook.com/book/0532/nodejs/details)
+    * [nodejs中文文档](https://www.gitbook.com/book/0532/nodejs/details) :worried:
     * [orm2 中文文档](https://github.com/wizardforcel/orm2-doc-zh-cn)
     * [一起学 Node.js](https://github.com/nswbmw/N-blog)
     * [Node入门：一本全面的Node.js教程](https://www.nodebeginner.org/index-zh-cn.html)
     * [从零开始的Nodejs系列文章](http://blog.fens.me/series-nodejs/)
 * underscore.js
-    * [Underscore.js中文文档](http://learningcn.com/underscore/)
+    * [Underscore.js中文文档](http://learningcn.com/underscore/) :worried:
 * backbone.js
-    * [backbone.js中文文档](http://www.css88.com/doc/backbone/)
+    * [backbone.js中文文档](http://www.css88.com/doc/backbone/) :worried:
     * [backbone.js入门教程](http://www.the5fire.com/backbone-js-tutorials-pdf-download.html) (PDF)
     * [Backbone.js入门教程第二版](https://github.com/the5fire/backbonejs-learning-note)
-    * [Developing Backbone.js Applications(中文版)](http://feliving.github.io/developing-backbone-applications/)
+    * [Developing Backbone.js Applications(中文版)](http://feliving.github.io/developing-backbone-applications/) :worried:
 * AngularJS
     * [AngularJS最佳实践和风格指南](https://github.com/mgechev/angularjs-style-guide/blob/master/README-zh-cn.md)
-    * [AngularJS中译本](https://github.com/peiransun/angularjs-cn)
+    * [AngularJS中译本](https://github.com/peiransun/angularjs-cn) :worried:
     * [AngularJS入门教程](https://github.com/zensh/AngularjsTutorial_cn)
     * [构建自己的AngularJS](https://github.com/xufei/Make-Your-Own-AngularJS/blob/master/01.md)
     * [在Windows环境下用Yeoman构建AngularJS项目](http://www.waylau.com/build-angularjs-app-with-yeoman-in-windows/)
 * Zepto.js
-    * [Zepto.js 中文文档](http://mweb.baidu.com/zeptoapi/)
+    * [Zepto.js 中文文档](http://mweb.baidu.com/zeptoapi/) :worried:
 * Sea.js
     * [Hello Sea.js](http://island205.github.io/HelloSea.js/)
 * React.js
     * [React 学习之道](https://github.com/the-road-to-learn-react/the-road-to-learn-react-chinese)
     * [React.js 小书](https://github.com/huzidaha/react-naive-book)
-    * [React.js 中文文档](https://doc.react-china.org/)
+    * [React.js 中文文档](https://doc.react-china.org/) :worried:
     * [React webpack-cookbook](https://github.com/fakefish/react-webpack-cookbook)
-    * [React 入门教程](http://fraserxu.me/intro-to-react/)
+    * [React 入门教程](http://fraserxu.me/intro-to-react/) :worried:
     * [React 入门教程](https://hulufei.gitbooks.io/react-tutorial/content/) (作者：hulufei, 与上行不同作者)
     * [React Native 中文文档(含最新Android内容)](http://wiki.jikexueyuan.com/project/react-native/)
     * [Learn React & Webpack by building the Hacker News front page](https://github.com/theJian/build-a-hn-front-page)
 * impress.js
     * [impress.js的中文教程](https://github.com/kokdemo/impress.js-tutorial-in-Chinese)
 * CoffeeScript
-    * [CoffeeScript Cookbook](http://island205.com/coffeescript-cookbook.github.com/)
-    * [The Little Book on CoffeeScript中文版](http://island205.com/tlboc/)
+    * [CoffeeScript Cookbook](http://island205.com/coffeescript-cookbook.github.com/) :worried:
+    * [The Little Book on CoffeeScript中文版](http://island205.com/tlboc/) :worried:
     * [CoffeeScript 编码风格指南](https://github.com/geekplux/coffeescript-style-guide)
 * TypeScipt
-    * [TypeScript Handbook](https://zhongsp.gitbooks.io/typescript-handbook/content/)
+    * [TypeScript Handbook](https://zhongsp.gitbooks.io/typescript-handbook/content/) :worried:
 * ExtJS
     * [Ext4.1.0 中文文档](http://extjs-doc-cn.github.io/ext4api/)
 * Meteor
     * [Discover Meteor](http://zh.discovermeteor.com/)
-    * [Meteor 中文文档](http://docs.meteorhub.org/#/basic/)
-    * [Angular-Meteor 中文教程](http://angular.meteorhub.org/)
+    * [Meteor 中文文档](http://docs.meteorhub.org/#/basic/) :worried:
+    * [Angular-Meteor 中文教程](http://angular.meteorhub.org/) :worried:
 * VueJS
     * [逐行剖析 Vue.js 源码](https://nlrx-wjc.github.io/Learn-Vue-Source-Code/)
-* [Chrome扩展及应用开发](http://www.ituring.com.cn/minibook/950)
+* [Chrome扩展及应用开发](http://www.ituring.com.cn/minibook/950) :worried:
 
 ## Kotlin
 * [Kotlin 官方参考文档 中文版](https://hltj.gitbooks.io/kotlin-reference-chinese/content/) 
 * [Kotlin 中文文档](https://huanglizhuo.gitbooks.io/kotlin-in-chinese/) [GitHub](https://github.com/huanglizhuo/kotlin-in-chinese)   
 * [Kotlin 参考文档](http://www.liying-cn.net/kotlin/docs/reference/)    
-* [《Kotlin for android developers》中文版](https://wangjiegulu.gitbooks.io/kotlin-for-android-developers-zh/content/)  
+* [《Kotlin for android developers》中文版](https://wangjiegulu.gitbooks.io/kotlin-for-android-developers-zh/content/) :worried:
 
 [返回目录](#目录)
 
@@ -645,7 +645,7 @@
 ## LISP
 * Common Lisp
     * [ANSI Common Lisp 中文翻譯版](http://acl.readthedocs.org/en/latest/)
-    * [On Lisp 中文翻译版本](http://www.ituring.com.cn/minibook/862)
+    * [On Lisp 中文翻译版本](http://www.ituring.com.cn/minibook/862) :worried:
 * Scheme
     * [Yet Another Scheme Tutorial Scheme入门教程](http://deathking.github.io/yast-cn/)
     * [Scheme语言简明教程](http://songjinghe.github.io/TYS-zh-translation/)
@@ -660,7 +660,7 @@
 * [Lua编程入门](https://github.com/andycai/luaprimer)
 * [Lua 5.1 参考手册 中文翻译](http://www.codingnow.com/2000/download/lua_manual.html)
 * [Lua 5.3 参考手册 中文翻译](http://cloudwu.github.io/lua53doc/)
-* [Lua源码欣赏](http://www.codingnow.com/temp/readinglua.pdf)
+* [Lua源码欣赏](http://www.codingnow.com/temp/readinglua.pdf) :worried:
 
 [返回目录](#目录)
 
@@ -672,7 +672,7 @@
 
 ## Perl
 
-* [Modern Perl 中文版](https://github.com/horus/modern_perl_book)
+* [Modern Perl 中文版](https://github.com/horus/modern_perl_book) :worried:
 * [Perl 程序员应该知道的事](http://perl.linuxtoy.org/)
 
 [返回目录](#目录)
@@ -683,20 +683,20 @@
 * [PHP调试技术手册](http://www.laruence.com/2010/06/21/1608.html)(PDF)
 * PHP之道：php-the-right-way ([@wulijun版](http://wulijun.github.io/php-the-right-way/) [PHPHub版](http://laravel-china.github.io/php-the-right-way/))
 * [PHP 最佳实践](https://github.com/justjavac/PHP-Best-Practices-zh_CN)
-* [PHP 开发者实践](https://ryancao.gitbooks.io/php-developer-prepares/content/)
+* [PHP 开发者实践](https://ryancao.gitbooks.io/php-developer-prepares/content/) :worried:
 * [深入理解PHP内核](https://github.com/reeze/tipi)
-* [PHP扩展开发及内核应用](http://www.walu.cc/phpbook/)
-* [Laravel5.1 中文文档](http://laravel-china.org/docs/5.1)
+* [PHP扩展开发及内核应用](http://www.walu.cc/phpbook/) :worried:
+* [Laravel5.1 中文文档](http://laravel-china.org/docs/5.1) :worried:
 * [Laravel 5.1 LTS 速查表](https://cs.phphub.org/)
 * [Symfony2 Cookbook 中文版](http://wiki.jikexueyuan.com/project/symfony-cookbook/)(版本 2.7.0 LTS)
 * [Symfony2中文文档](http://symfony-docs-chs.readthedocs.org/en/latest/) (未译完)
-* [YiiBook几本Yii框架的在线教程](http://yiibook.com//doc)
-* [深入理解 Yii 2.0](http://www.digpage.com/)
+* [YiiBook几本Yii框架的在线教程](http://yiibook.com//doc) :worried:
+* [深入理解 Yii 2.0](http://www.digpage.com/) :worried:
 * [Yii 框架中文官网](http://www.yiichina.com/)
-* [简单易懂的PHP魔法](http://www.nowamagic.net/librarys/books/contents/php)
+* [简单易懂的PHP魔法](http://www.nowamagic.net/librarys/books/contents/php) :worried:
 * [swoole文档及入门教程](https://github.com/LinkedDestiny/swoole-doc)
 * [Composer 中文网](http://www.phpcomposer.com)
-* [Slim 中文文档](http://ww1.minimee.org/php/slim)
+* [Slim 中文文档](http://ww1.minimee.org/php/slim) :worried:
 * [Lumen 中文文档](http://lumen.laravel-china.org/)
 * [PHPUnit 中文文档](https://phpunit.de/manual/current/zh_cn/installation.html)
 * [PHP-LeetCode](https://github.com/wuqinqiang/leetcode-php)
@@ -713,10 +713,10 @@
 
 ## Python
 
-* [廖雪峰 Python 2.7 中文教程](http://www.liaoxuefeng.com/wiki/001374738125095c955c1e6d8bb493182103fac9270762a000)
+* [廖雪峰 Python 2.7 中文教程](http://www.liaoxuefeng.com/wiki/001374738125095c955c1e6d8bb493182103fac9270762a000) :worried:
 * [廖雪峰 Python 3 中文教程](http://www.liaoxuefeng.com/wiki/0014316089557264a6b348958f449949df42a6d3a2e542c000)
-* [简明Python教程](http://www.kuqin.com/abyteofpython_cn/)
-* [简明 Python 教程(Python 3)](https://legacy.gitbook.com/book/lenkimo/byte-of-python-chinese-edition/details)
+* [简明Python教程](http://www.kuqin.com/abyteofpython_cn/) :worried:
+* [简明 Python 教程(Python 3)](https://legacy.gitbook.com/book/lenkimo/byte-of-python-chinese-edition/details) :worried:
 * [零基础学 Python 第一版](http://www.kancloud.cn/kancloud/python-basic)
 * [零基础学 Python 第二版](http://www.kancloud.cn/kancloud/starter-learning-python)
 * [可爱的 Python](http://lovelypython.readthedocs.org/en/latest/)
@@ -724,13 +724,13 @@
 * [Python 3.3 官方教程中文版](http://www.pythondoc.com/pythontutorial3/index.html)
 * [Python Cookbook 中文版](http://www.kancloud.cn/thinkphp/python-cookbook)
 * [Python3 Cookbook 中文版](https://github.com/yidao620c/python3-cookbook)
-* [深入 Python](http://www.kuqin.com/docs/diveintopythonzh-cn-5.4b/html/toc/)
-* [深入 Python 3](http://old.sebug.net/paper/books/dive-into-python3/)
+* [深入 Python](http://www.kuqin.com/docs/diveintopythonzh-cn-5.4b/html/toc/) :worried:
+* [深入 Python 3](http://old.sebug.net/paper/books/dive-into-python3/) :worried:
 * [PEP8 Python代码风格规范](https://code.google.com/p/zhong-wiki/wiki/PEP8)
 * [Google Python 风格指南 中文版](http://zh-google-styleguide.readthedocs.org/en/latest/google-python-styleguide/)
 * [Python入门教程](http://liam0205.me/2013/11/02/Python-tutorial-zh_cn/) ([PDF](http://liam0205.me/attachment/Python/The_Python_Tutorial_zh-cn.pdf))
 * [笨办法学 Python](http://old.sebug.net/paper/books/LearnPythonTheHardWay/) ([PDF](http://liam0205.me/attachment/Python/PyHardWay/Learn_Python_The_Hard_Way_zh-cn.pdf) [EPUB](https://www.gitbook.com/download/epub/book/wizardforcel/lpthw))
-* [Python自然语言处理中文版](http://pan.baidu.com/s/1qW4pvnY) （感谢陈涛同学的翻译，也谢谢 [@shwley](https://github.com/shwley) 联系了作者）
+* [Python自然语言处理中文版](http://pan.baidu.com/s/1qW4pvnY) （感谢陈涛同学的翻译，也谢谢 [@shwley](https://github.com/shwley) 联系了作者） :worried:
 * [Python 绘图库 matplotlib 官方指南中文翻译](http://liam0205.me/2014/09/11/matplotlib-tutorial-zh-cn/)
 * [Scrapy 0.25 文档](http://scrapy-chs.readthedocs.org/zh_CN/latest/)
 * [ThinkPython](https://github.com/carfly/thinkpython-cn)
@@ -738,30 +738,30 @@
 * [Python快速教程](http://www.cnblogs.com/vamei/archive/2012/09/13/2682778.html)
 * [Python 正则表达式操作指南](http://wiki.ubuntu.org.cn/Python正则表达式操作指南)
 * [python初级教程：入门详解](http://www.crifan.com/files/doc/docbook/python_beginner_tutorial/release/html/python_beginner_tutorial.html)
-* [Twisted 与异步编程入门](https://www.gitbook.com/book/likebeta/twisted-intro-cn/details)
+* [Twisted 与异步编程入门](https://www.gitbook.com/book/likebeta/twisted-intro-cn/details) :worried:
 * [TextGrocery 中文 API](http://textgrocery.readthedocs.org/zh/latest/index.html) ( 基于svm算法的一个短文本分类 Python 库 )
 * [Requests: HTTP for Humans](http://requests-docs-cn.readthedocs.org/zh_CN/latest/)
-* [Pillow 中文文档](http://pillow-cn.readthedocs.org/en/latest/#)
+* [Pillow 中文文档](http://pillow-cn.readthedocs.org/en/latest/#) :worried:
 * [PyMOTW 中文版](http://pymotwcn.readthedocs.org/en/latest/index.html)
-* [Python 官方文档中文版](http://data.digitser.net/zh-CN/python_index.html)
+* [Python 官方文档中文版](http://data.digitser.net/zh-CN/python_index.html) :worried:
 * [Fabric 中文文档](http://fabric-chs.readthedocs.org)
 * [Beautiful Soup 4.2.0 中文文档](http://beautifulsoup.readthedocs.org/zh_CN/latest/)
-* [Python 中的 Socket 编程](https://legacy.gitbook.com/book/keelii/socket-programming-in-python-cn/details)
+* [Python 中的 Socket 编程](https://legacy.gitbook.com/book/keelii/socket-programming-in-python-cn/details) :worried:
 * [用Python做科学计算](https://docs.huihoo.com/scipy/scipy-zh-cn/index.html)
 * [Sphinx 中文文档](http://www.pythondoc.com/sphinx/index.html)
 * [精通 Python 设计模式](https://github.com/cundi/Mastering.Python.Design.Patterns)
 * [python 安全编程教程](https://github.com/smartFlash/pySecurity)
-* [程序设计思想与方法](https://www.gitbook.com/book/wizardforcel/sjtu-cs902-courseware/details)
-* [知乎周刊·编程小白学Python](https://read.douban.com/ebook/16691849/)
+* [程序设计思想与方法](https://www.gitbook.com/book/wizardforcel/sjtu-cs902-courseware/details) :worried:
+* [知乎周刊·编程小白学Python](https://read.douban.com/ebook/16691849/) :worried:
 * [Scipy 讲义](https://github.com/cloga/scipy-lecture-notes_cn)
-* [Python 学习笔记 基础篇](http://www.kuqin.com/docs/pythonbasic.html)
-* [Python 学习笔记 模块篇](http://www.kuqin.com/docs/pythonmodule.html)
+* [Python 学习笔记 基础篇](http://www.kuqin.com/docs/pythonbasic.html) :worried:
+* [Python 学习笔记 模块篇](http://www.kuqin.com/docs/pythonmodule.html) :worried:
 * [Python 标准库 中文版](http://old.sebug.net/paper/books/python/%E3%80%8APython%E6%A0%87%E5%87%86%E5%BA%93%E3%80%8B%E4%B8%AD%E6%96%87%E7%89%88.pdf)
-* [Python进阶](https://www.gitbook.com/book/eastlakeside/interpy-zh/details)
-* [Python 核心编程 第二版](https://wizardforcel.gitbooks.io/core-python-2e/content/) CPyUG译
+* [Python进阶](https://www.gitbook.com/book/eastlakeside/interpy-zh/details) :worried:
+* [Python 核心编程 第二版](https://wizardforcel.gitbooks.io/core-python-2e/content/) CPyUG译 :worried:
 * [Python最佳实践指南](http://pythonguidecn.readthedocs.io/zh/latest/)
-* [Python 精要教程](https://www.gitbook.com/book/wizardforcel/python-essential-tutorial/details)
-* [Python 量化交易教程](https://www.gitbook.com/book/wizardforcel/python-quant-uqer/details)
+* [Python 精要教程](https://www.gitbook.com/book/wizardforcel/python-essential-tutorial/details) :worried:
+* [Python 量化交易教程](https://www.gitbook.com/book/wizardforcel/python-quant-uqer/details) :worried:
 * [Python黑魔法手册](https://magic.iswbm.com/preface.html)
 * Django
     * [Django 1.5 文档中文版](http://django-chinese-docs.readthedocs.org/en/latest/) 正在翻译中
@@ -772,22 +772,22 @@
     * [The Django Book 中文版](http://djangobook.py3k.cn/2.0/)
     * [Django 设计模式与最佳实践](https://github.com/cundi/Django-Design-Patterns-and-Best-Practices)
     * [Django 网站开发 Cookbook](https://github.com/cundi/Web.Development.with.Django.Cookbook)
-    * [Django Girls 學習指南](https://www.gitbook.com/book/djangogirlstaipei/django-girls-taipei-tutorial/details)
+    * [Django Girls 學習指南](https://www.gitbook.com/book/djangogirlstaipei/django-girls-taipei-tutorial/details) :worried:
 * Flask
     * [Flask 文档中文版](http://docs.jinkan.org/docs/flask/)
     * [Jinja2 文档中文版](http://docs.jinkan.org/docs/jinja2/)
     * [Werkzeug 文档中文版](http://werkzeug-docs-cn.readthedocs.org/zh_CN/latest/)
     * [Flask之旅](http://spacewander.github.io/explore-flask-zh/)
-    * [Flask 扩展文档汇总](https://www.gitbook.com/book/wizardforcel/flask-extension-docs/details)
+    * [Flask 扩展文档汇总](https://www.gitbook.com/book/wizardforcel/flask-extension-docs/details) :worried:
     * [Flask 大型教程](http://www.pythondoc.com/flask-mega-tutorial/index.html)
     * [SQLAlchemy 中文文档](http://docs.jinkan.org/docs/flask-sqlalchemy/)
     * [Flask 入门教程](https://read.helloflask.com)
 * web.py
-    * [web.py 0.3 新手指南](http://webpy.org/tutorial3.zh-cn)
+    * [web.py 0.3 新手指南](http://webpy.org/tutorial3.zh-cn) :worried:
     * [Web.py Cookbook 简体中文版](http://webpy.org/cookbook/index.zh-cn)
 * Tornado
     * [Introduction to Tornado 中文翻译](http://demo.pythoner.com/itt2zh/index.html)
-    * [Tornado源码解析](http://www.nowamagic.net/academy/detail/13321002)
+    * [Tornado源码解析](http://www.nowamagic.net/academy/detail/13321002) :worried:
     * [Tornado 4.3 文档中文版](https://tornado-zh.readthedocs.org/zh/latest/)
 
 [返回目录](#目录)
@@ -804,13 +804,13 @@
 * [Ruby 风格指南](https://github.com/JuanitoFatas/ruby-style-guide/blob/master/README-zhCN.md)
 * [Rails 风格指南](https://github.com/JuanitoFatas/rails-style-guide/blob/master/README-zhCN.md)
 * [笨方法學 Ruby](http://lrthw.github.io/)
-* [Ruby on Rails 指南](http://guides.ruby-china.org/)
+* [Ruby on Rails 指南](http://guides.ruby-china.org/) :worried:
 * [Ruby on Rails 實戰聖經](https://ihower.tw/rails4/index.html)
-* [Ruby on Rails Tutorial 原书第 3 版](http://railstutorial-china.org/) (本书网页版免费提供，电子版以 PDF、EPub 和 Mobi 格式提供购买，仅售 9.9 美元)
-* [Rails 实践](http://rails-practice.com/content/index.html)
-* [Rails 5 开发进阶(Beta)](https://www.gitbook.com/book/kelby/rails-beginner-s-guide/details)
-* [Rails 102](https://www.gitbook.com/book/rocodev/rails-102/details)
-* [编写Ruby的C拓展](https://wusuopu.gitbooks.io/write-ruby-extension-with-c/content/)
+* [Ruby on Rails Tutorial 原书第 3 版](http://railstutorial-china.org/) (本书网页版免费提供，电子版以 PDF、EPub 和 Mobi 格式提供购买，仅售 9.9 美元) :worried:
+* [Rails 实践](http://rails-practice.com/content/index.html) :worried:
+* [Rails 5 开发进阶(Beta)](https://www.gitbook.com/book/kelby/rails-beginner-s-guide/details) :worried:
+* [Rails 102](https://www.gitbook.com/book/rocodev/rails-102/details) :worried:
+* [编写Ruby的C拓展](https://wusuopu.gitbooks.io/write-ruby-extension-with-c/content/) :worried:
 * [Ruby 源码解读](https://ruby-china.org/topics/22386)
 * [Ruby中的元编程](http://deathking.github.io/metaprogramming-in-ruby/)
 
@@ -828,27 +828,27 @@
 
 * [Scala课堂](http://twitter.github.io/scala_school/zh_cn/index.html) (Twitter的Scala中文教程)
 * [Effective Scala](http://twitter.github.io/effectivescala/index-cn.html)(Twitter的Scala最佳实践的中文翻译)
-* [Scala指南](http://zh.scala-tour.com/)
+* [Scala指南](http://zh.scala-tour.com/) :worried:
 
 [返回目录](#目录)
 
 ## Shell
 
 * [Shell脚本编程30分钟入门](https://github.com/qinjx/30min_guides/blob/master/shell.md)
-* [Bash脚本15分钟进阶教程](http://blog.sae.sina.com.cn/archives/3606)
+* [Bash脚本15分钟进阶教程](http://blog.sae.sina.com.cn/archives/3606) :worried:
 * [Linux工具快速教程](https://github.com/me115/linuxtools_rst)
 * [shell十三问](https://github.com/wzb56/13_questions_of_shell)
-* [Shell编程范例](https://www.gitbook.com/book/tinylab/shellbook/details)
+* [Shell编程范例](https://www.gitbook.com/book/tinylab/shellbook/details) :worried:
 * [Linux命令搜索引擎](https://wangchujiang.com/linux-command/)
 
 [返回目录](#目录)
 
 ## Swift
 
-* [The Swift Programming Language 中文版](http://numbbbbb.github.io/the-swift-programming-language-in-chinese/)
-* [Swift 语言指南](http://dev.swiftguide.cn)
+* [The Swift Programming Language 中文版](http://numbbbbb.github.io/the-swift-programming-language-in-chinese/) :worried:
+* [Swift 语言指南](http://dev.swiftguide.cn) :worried:
 * [Stanford 公开课，Developing iOS 8 Apps with Swift 字幕翻译文件](https://github.com/x140yu/Developing_iOS_8_Apps_With_Swift)
-* [C4iOS - COSMOS](http://c4ios.swift.gg)
+* [C4iOS - COSMOS](http://c4ios.swift.gg) :worried:
 
 [返回目录](#目录)
 
@@ -856,29 +856,29 @@
 
 * [编译原理（紫龙书）中文第2版习题答案](https://github.com/fool2fish/dragon-book-exercise-answers)
 * [把《编程珠玑》读薄](http://hawstein.com/2013/08/11/make-thiner-programming-pearls/)
-* [Effective C++读书笔记](https://github.com/XiaolongJason/ReadingNote/blob/master/Effective%20C%2B%2B/Effective%20C%2B%2B.md)
+* [Effective C++读书笔记](https://github.com/XiaolongJason/ReadingNote/blob/master/Effective%20C%2B%2B/Effective%20C%2B%2B.md) :worried:
 * [Golang 学习笔记、Python 学习笔记、C 学习笔记](https://github.com/qyuhen/book) (PDF)
 * [Jsoup 学习笔记](https://github.com/code4craft/jsoup-learning)
 * [学习笔记: Vim、Python、memcached](https://github.com/lzjun567/note)
-* [图灵开放书翻译计划--C++、Python、Java等](http://www.ituring.com.cn/activity/details/2004)
-* [蒂姆·奥莱利随笔](http://g.yeeyan.org/books/2095) （由译言网翻译，电子版免费）
+* [图灵开放书翻译计划--C++、Python、Java等](http://www.ituring.com.cn/activity/details/2004) :worried:
+* [蒂姆·奥莱利随笔](http://g.yeeyan.org/books/2095) （由译言网翻译，电子版免费） :worried:
 * [SICP 解题集](http://sicp.readthedocs.org/en/latest/)
 * [精彩博客集合](https://github.com/hacke2/hacke2.github.io/issues/2)
 * [中文文案排版指北](https://github.com/sparanoid/chinese-copywriting-guidelines)
-* [Standard C 语言标准函数库速查 (Cheat Sheet)](http://ganquan.info/standard-c/)
-* [Git Cheatsheet Chs](http://gh.amio.us/git-cheatsheet-chs/)
-* [GitBook简明教程](http://www.chengweiyang.cn/gitbook/index.html)
+* [Standard C 语言标准函数库速查 (Cheat Sheet)](http://ganquan.info/standard-c/) :worried:
+* [Git Cheatsheet Chs](http://gh.amio.us/git-cheatsheet-chs/) :worried:
+* [GitBook简明教程](http://www.chengweiyang.cn/gitbook/index.html) :worried:
 * [制造开源软件](http://producingoss.com/zh/)
-* [提问的智慧](http://www.dianbo.org/9238/stone/tiwendezhihui.htm)
+* [提问的智慧](http://www.dianbo.org/9238/stone/tiwendezhihui.htm) :worried:
 * [Markdown 入门参考](https://github.com/LearnShare/Learning-Markdown)
 * [AsciiDoc简明指南](https://github.com/stanzgy/wiki/blob/master/markup/asciidoc-guide.asciidoc)
 * [背包问题九讲](http://love-oriented.com/pack/)
 * [老齐的技术资料](https://github.com/qiwsir/ITArticles)
 * [前端技能汇总](https://github.com/JacksonTian/fks)
 * [借助开源项目，学习软件开发](https://github.com/zhuangbiaowei/learn-with-open-source)
-* [前端工作面试问题](https://github.com/h5bp/Front-end-Developer-Interview-Questions/tree/master/Translations/Chinese)
-* [leetcode/lintcode题解/算法学习笔记](https://www.gitbook.com/book/yuanbin/algorithm/details)
-* [前端开发笔记本](https://github.com/li-xinyang/FEND_Note)
+* [前端工作面试问题](https://github.com/h5bp/Front-end-Developer-Interview-Questions/tree/master/Translations/Chinese) :worried:
+* [leetcode/lintcode题解/算法学习笔记](https://www.gitbook.com/book/yuanbin/algorithm/details) :worried:
+* [前端开发笔记本](https://github.com/li-xinyang/FEND_Note) :worried:
 * [LeetCode题解](https://siddontang.gitbooks.io/leetcode-solution/content/)
 * [《不可替代的团队领袖培养计划》](https://leader.js.cool/#/)
 


### PR DESCRIPTION
本来只想看看大数据的资料，结果五条链接失效三条 :worried:
所以顺便把全部链接测试了一遍

gitbook 和 图灵(ituring) 还有 百度阅读 等的链接全军覆没
不清楚是否是只更换了链接格式而资源还在，反正目前是都看不了，我就都标上了
**由于标注量大，不保证是否有遗漏或误标**