### PR TITLE
docs: 修复 Javascript 源码链接中的拼写错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@
 * [Google JSON 风格指南](https://github.com/darcyliu/google-styleguide/blob/master/JSONStyleGuide.md)
 * [Airbnb JavaScript 规范](https://github.com/adamlu/javascript-style-guide)
 * [JavaScript 标准参考教程（alpha）](http://javascript.ruanyifeng.com/)
-* [Javascript编程指南](http://pij.robinqu.me/) ([源码](https://github.com/RobinQu/Programing-In-Javascript))
+* [Javascript编程指南](http://pij.robinqu.me/) ([源码](https://github.com/RobinQu/Programming-In-Javascript))
 * [javascript 的 12 个怪癖](https://github.com/justjavac/12-javascript-quirks)
 * [JavaScript 秘密花园](http://bonsaiden.github.io/JavaScript-Garden/zh/) :worried:
 * [JavaScript核心概念及实践](http://icodeit.org/jsccp/) (PDF) (此书已由人民邮电出版社出版发行，但作者依然免费提供PDF版本，希望开发者们去购买，支持作者) :worried:


### PR DESCRIPTION
将 'Programing-In-Javascript' 修复为 'Programming-In-Javascript'。