### PR TITLE
docs: 为失效链接添加 :worried: 标记

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@
 * [Go语言博客实践](https://github.com/achun/Go-Blog-In-Action)
 * [Go 官方文档翻译](https://github.com/golang-china/golangdoc.translations)
 * [深入解析Go](https://github.com/tiancaiamao/go-internals)
-* [Go语言圣经(中文版)](https://bitbucket.org/golang-china/gopl-zh/wiki/Home) ([GitBook](https://www.gitbook.com/book/wizardforcel/gopl-zh/details))
+* [Go语言圣经(中文版)](https://bitbucket.org/golang-china/gopl-zh/wiki/Home) ([GitBook](https://www.gitbook.com/book/wizardforcel/gopl-zh/details)) :worried:
 * [golang runtime源码分析](https://github.com/sheepbao/golang_runtime_reading)
 * [Go语言实战: 编写可维护Go语言代码建议](https://github.com/llitfkitfk/go-best-practice)
 * [Golang 系列教程(译)](https://github.com/Tinywan/golang-tutorial)   


### PR DESCRIPTION
### 变更说明
按照仓库贡献说明，为无法访问的链接添加 `:worried:` 标记。

### 修改详情
- `README.md`：go 节「Go语言圣经(中文版) (GitBook)」处链接已验证无法访问，追加标记。

### 验证情况
- 已手动确认对应链接当前无法正常访问
- 未修改原文内容与其他格式