### PR TITLE
remove 编程网站 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@
 
 贡献者名单: https://github.com/justjavac/free-programming-books-zh_CN/graphs/contributors
 
-## 编程网站
-* [AICodeConvert](http://www.aicodeconvert.com) 
-  * 可以将自然语言转为代码实现
-  * 可以将已有语言代码转为另一种代码语言
-  * 可以代码debug、优化、解释
-
 ## 目录
 
 * 语言无关类


### PR DESCRIPTION
Revert the "编程网站" section (AICodeConvert entry) added in 2ca0d17 (#877), as it is promotional content rather than a free programming book/resource.