### PR TITLE
fix links: vhf → EbookFoundation, jcohy-docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 - 国外程序员在 [stackoverflow](http://stackoverflow.com/questions/1711/what-is-the-single-most-influential-book-every-programmer-should-read/1713%231713) 推荐的程序员必读书籍，[中文版](http://justjavac.com/other/2012/05/15/qualified-programmer-should-read-what-books.html "一个合格的程序员应该读过哪些书")。
 - [stackoverflow](http://stackoverflow.com/questions/38210/what-non-programming-books-should-programmers-read) 上的程序员应该阅读的非编程类书籍有哪些？ [中文版](what-non-programming-books-should-programmers-read.md)
-- [github](https://github.com/vhf/free-programming-books) 上的一个流行的编程书籍索引  [中文版](https://github.com/vhf/free-programming-books/blob/master/free-programming-books-zh.md)
+- [github](https://github.com/EbookFoundation/free-programming-books) 上的一个流行的编程书籍索引  [中文版](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-zh.md)
 
 如果这个仓库对你有帮助，欢迎 star。如果这个仓库帮你提升了技能找到了工作，可以请我喝杯咖啡：
 
@@ -520,7 +520,7 @@
 * [Jersey 2.x 用户指南](https://github.com/waylau/Jersey-2.x-User-Guide)
 * [Spring Framework 4.x参考文档](https://github.com/waylau/spring-framework-4-reference)
 * [Spring Boot参考指南](https://github.com/qibaoguang/Spring-Boot-Reference-Guide) (翻译中)
-* [Spring 系列中文参考指南](https://github.com/jcohy/jcohy-docs.git)
+* [Spring 系列中文参考指南](https://github.com/jcohy/jcohy-docs)
 * [MyBatis中文文档](http://mybatis.org/mybatis-3/zh/index.html)
 * [MyBatis Generator 中文文档](http://mbg.cndocs.tk/) :worried:
 * [用jersey构建REST服务](https://github.com/waylau/RestDemo)


### PR DESCRIPTION
两个收尾修复（源自已关闭 PR 中指出的真实问题）：

- 开头的 free-programming-books 索引链接从 vhf 仓库更新为 EbookFoundation 仓库新地址（旧中文版链接 404，见 #843、#885）
- Spring 系列中文参考指南 URL 去掉末尾 `.git`（#858 合并时未带上的修正）