### PR TITLE
为失效链接更换备份地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
 * [Mac 开发配置手册](https://aaaaaashu.gitbooks.io/mac-dev-setup/content/)
 * [FreeBSD 使用手册](https://www.freebsd.org/doc/zh_CN/books/handbook/index.html)
 * [Linux 命令行(中文版)](http://billie66.github.io/TLCL/book/)
-* [Linux 构建指南](http://works.jinbuguo.com/lfs/lfs62/index.html) :worried:
+* [Linux 构建指南](https://www.jinbuguo.com/lfs/lfs62/index.html)
 * [Linux工具快速教程](https://github.com/me115/linuxtools_rst)
 * [Linux Documentation (中文版)](https://www.gitbook.com/book/tinylab/linux-doc/details) :worried:
 * [嵌入式 Linux 知识库 (eLinux.org 中文版)](https://www.gitbook.com/book/tinylab/elinux/details) :worried:
@@ -150,7 +150,7 @@
 * [Nginx开发从入门到精通](http://tengine.taobao.org/book/index.html) (淘宝团队出品)
 * [Nginx教程从入门到精通](http://www.ttlsa.com/nginx/nginx-stu-pdf/)(PDF版本，运维生存时间出品) :worried:
 * [OpenResty最佳实践](https://www.gitbook.com/book/moonbingbing/openresty-best-practices/details) :worried:
-* [Apache 中文手册](http://works.jinbuguo.com/apache/menu22/index.html) :worried:
+* [Apache 中文手册](https://www.jinbuguo.com/apache/manual/index.html)
 
 [返回目录](#目录)
 
@@ -215,7 +215,7 @@
 
 ## PostgreSQL
 
-* [PostgreSQL 8.2.3 中文文档](http://works.jinbuguo.com/postgresql/menu823/index.html) :worried:
+* [PostgreSQL 8.2.3 中文文档](https://www.jinbuguo.com/postgresql/manual/index.html)
 * [PostgreSQL 9.3.1 中文文档](http://www.postgres.cn/docs/9.3/index.html)
 * [PostgreSQL 9.5.3 中文文档](http://www.postgres.cn/docs/9.5/index.html)
 

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@
 * [Google Objective-C Style Guide 中文版](https://zh-google-styleguide.readthedocs.io/en/latest/google-objc-styleguide/)
 * [iPhone 6 屏幕揭秘](http://wileam.com/iphone-6-screen-cn/)
 * [Apple Watch开发初探](http://nilsun.github.io/apple-watch/) :worried:
-* [马上着手开发 iOS 应用程序](https://developer.apple.com/library/ios/referencelibrary/GettingStarted/RoadMapiOSCh/index.html) :worried:
+* [马上着手开发 iOS 应用程序](https://developer.apple.com/library/archive/referencelibrary/GettingStarted/RoadMapiOSCh-Legacy/index.html)
 * [网易斯坦福大学公开课：iOS 7应用开发字幕文件](https://github.com/jkyin/Subtitle)
 
 [返回目录](#目录)
@@ -521,7 +521,7 @@
 * [Spring Framework 4.x参考文档](https://github.com/waylau/spring-framework-4-reference)
 * [Spring Boot参考指南](https://github.com/qibaoguang/Spring-Boot-Reference-Guide) (翻译中)
 * [Spring 系列中文参考指南](https://github.com/jcohy/jcohy-docs)
-* [MyBatis中文文档](http://mybatis.org/mybatis-3/zh/index.html) :worried:
+* [MyBatis中文文档](https://mybatis.org/mybatis-3/zh_CN/index.html)
 * [MyBatis Generator 中文文档](http://mbg.cndocs.tk/) :worried:
 * [用jersey构建REST服务](https://github.com/waylau/RestDemo)
 * [Activiti 5.x 用户指南](https://github.com/waylau/activiti-5.x-user-guide)
@@ -625,7 +625,7 @@
 * ExtJS
     * [Ext4.1.0 中文文档](http://extjs-doc-cn.github.io/ext4api/)
 * Meteor
-    * [Discover Meteor](http://zh.discovermeteor.com/) :worried:
+    * [Discover Meteor](https://github.com/DiscoverMeteor/DiscoverMeteor_zh)
     * [Meteor 中文文档](http://docs.meteorhub.org/#/basic/) :worried:
     * [Angular-Meteor 中文教程](http://angular.meteorhub.org/) :worried:
 * VueJS
@@ -703,7 +703,7 @@
 * [swoole文档及入门教程](https://github.com/LinkedDestiny/swoole-doc)
 * [Composer 中文网](http://www.phpcomposer.com)
 * [Slim 中文文档](http://ww1.minimee.org/php/slim) :worried:
-* [Lumen 中文文档](http://lumen.laravel-china.org/) :worried:
+* [Lumen 中文文档](https://learnku.com/docs/lumen/5.7/)
 * [PHPUnit 中文文档](https://phpunit.de/manual/current/zh_cn/installation.html) :worried:
 * [PHP-LeetCode](https://github.com/wuqinqiang/leetcode-php)
 * [ThinkPHP5.1完全开发手册](https://www.kancloud.cn/manual/thinkphp5_1)
@@ -772,7 +772,7 @@
     * [Django 1.5 文档中文版](https://django-chinese-docs.readthedocs.io/en/latest/) 正在翻译中
     * [Django 2.0 文档中文版](https://docs.djangoproject.com/zh-hans/2.0/)
     * [Django 最佳实践](https://github.com/yangyubo/zh-django-best-practices)
-    * [Django 2.1 搭建个人博客教程](https://www.dusaiphoto.com/article/detail/2/) ( 编写中 ) :worried:
+    * [Django 搭建个人博客教程](https://github.com/stacklens/django_blog_tutorial)
     * [Django搭建简易博客教程](https://www.gitbook.com/book/andrew-liu/django-blog/details)
     * [The Django Book 中文版](http://djangobook.py3k.cn/2.0/)
     * [Django 设计模式与最佳实践](https://github.com/cundi/Django-Design-Patterns-and-Best-Practices)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 免费的编程中文书籍索引，欢迎投稿。
 
 - 国外程序员在 [stackoverflow](http://stackoverflow.com/questions/1711/what-is-the-single-most-influential-book-every-programmer-should-read/1713%231713) 推荐的程序员必读书籍，[中文版](http://justjavac.com/other/2012/05/15/qualified-programmer-should-read-what-books.html "一个合格的程序员应该读过哪些书")。
-- [stackoverflow](http://stackoverflow.com/questions/38210/what-non-programming-books-should-programmers-read) 上的程序员应该阅读的非编程类书籍有哪些？ [中文版](what-non-programming-books-should-programmers-read.md) :worried:
+- 程序员应该阅读的非编程类书籍有哪些？ [中文版](what-non-programming-books-should-programmers-read.md)（原帖为 stackoverflow 上已删除的[问题 38210](https://web.archive.org/web/20170103152138/http://stackoverflow.com/questions/38210/what-non-programming-books-should-programmers-read)）
 - [github](https://github.com/EbookFoundation/free-programming-books) 上的一个流行的编程书籍索引  [中文版](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-zh.md)
 
 如果这个仓库对你有帮助，欢迎 star。如果这个仓库帮你提升了技能找到了工作，可以请我喝杯咖啡：
@@ -207,7 +207,7 @@
 * [The Little MongoDB Book](https://github.com/justinyhuang/the-little-mongodb-book-cn/blob/master/mongodb.md)
 * [The Little Redis Book](https://github.com/JasonLai256/the-little-redis-book/blob/master/cn/redis.md)
 * [Neo4j 简体中文手册 v1.8](http://docs.neo4j.org.cn/) :worried:
-* [Neo4j .rb 中文資源](http://neo4j.tw/) :worried:
+* [Neo4j .rb 中文資源](https://web.archive.org/web/20130716014446/http://neo4j.tw/) :worried:
 * [Disque 使用教程](http://disquebook.com) :worried:
 * [Apache Spark 设计与实现](https://github.com/JerryLead/SparkInternals/tree/master/markdown)
 
@@ -242,8 +242,8 @@
 ## 项目相关
 
 * [持续集成（第二版）](http://article.yeeyan.org/view/2251/94882) (译言网) :worried:
-* [让开发自动化系列专栏](http://www.ibm.com/developerworks/cn/java/j-ap/) :worried:
-* [追求代码质量](http://www.ibm.com/developerworks/cn/java/j-cq/) :worried:
+* [让开发自动化系列专栏](https://web.archive.org/web/20181023074323/https://www.ibm.com/developerworks/cn/java/j-ap/) :worried:
+* [追求代码质量](https://web.archive.org/web/20181023194039/https://www.ibm.com/developerworks/cn/java/j-cq/) :worried:
 * [selenium 中文文档](https://github.com/fool2fish/selenium-doc) :worried:
 * [Selenium Webdriver 简易教程](https://github.com/it-ebooks-0/it-ebooks-2016-allinone/blob/master/Selenium%20Webdriver%20%E7%AE%80%E6%98%93%E6%95%99%E7%A8%8B.epub) (EPUB)
 * [Joel谈软件](http://local.joelonsoftware.com/wiki/Chinese_\(Simplified\)) :worried:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@
 ## WEB服务器
 
 * [Nginx开发从入门到精通](http://tengine.taobao.org/book/index.html) (淘宝团队出品)
-* [Nginx教程从入门到精通](http://www.ttlsa.com/nginx/nginx-stu-pdf/)(PDF版本，运维生存时间出品) :worried:
+* [Nginx教程从入门到精通](https://github.com/parieses/source/blob/master/Nginx%E6%95%99%E7%A8%8B%E4%BB%8E%E5%85%A5%E9%97%A8%E5%88%B0%E7%B2%BE%E9%80%9A(%E8%BF%90%E7%BB%B4%E7%94%9F%E5%AD%98%E6%97%B6%E9%97%B4TTLSA%E5%87%BA%E5%93%81).pdf)(PDF版本，运维生存时间出品)
 * [OpenResty最佳实践](https://www.gitbook.com/book/moonbingbing/openresty-best-practices/details) :worried:
 * [Apache 中文手册](https://www.jinbuguo.com/apache/manual/index.html)
 
@@ -245,7 +245,7 @@
 * [让开发自动化系列专栏](http://www.ibm.com/developerworks/cn/java/j-ap/) :worried:
 * [追求代码质量](http://www.ibm.com/developerworks/cn/java/j-cq/) :worried:
 * [selenium 中文文档](https://github.com/fool2fish/selenium-doc) :worried:
-* [Selenium Webdriver 简易教程](http://it-ebooks.flygon.net/selenium-simple-tutorial/) :worried:
+* [Selenium Webdriver 简易教程](https://github.com/it-ebooks-0/it-ebooks-2016-allinone/blob/master/Selenium%20Webdriver%20%E7%AE%80%E6%98%93%E6%95%99%E7%A8%8B.epub) (EPUB)
 * [Joel谈软件](http://local.joelonsoftware.com/wiki/Chinese_\(Simplified\)) :worried:
 * [約耳談軟體(Joel on Software)](http://local.joelonsoftware.com/wiki/%E9%A6%96%E9%A0%81) :worried:
 * [Gradle 2 用户指南](https://github.com/waylau/Gradle-2-User-Guide)
@@ -263,7 +263,7 @@
 
 * [图说设计模式](https://github.com/me115/design_patterns)
 * [史上最全设计模式导学目录](http://blog.csdn.net/lovelion/article/details/17517213)
-* [design pattern 包教不包会](https://github.com/AlfredTheBest/Design-Pattern) :worried:
+* [design pattern 包教不包会](https://github.com/MiaoJoy/Design-Pattern)
 * [设计模式 Java 版](https://quanke.gitbooks.io/design-pattern-java/content/) :worried:
 * [设计模式目录](https://refactoringguru.cn/design-patterns/catalog)
 
@@ -384,7 +384,7 @@
 * [ZMQ 指南](https://github.com/anjuke/zguide-cn)
 * [How to Think Like a Computer Scientist](http://www.ituring.com.cn/book/1203) (中英文版)
 * [跟我一起写 Makefile](https://github.com/seisman/how-to-write-makefile)
-* [GNU make中文手册](https://free-online-ebooks.appspot.com/tools/gnu-make-cn/) (需科学上网) ([PDF](https://hacker-yhj.github.io/resources/gun_make.pdf)) :worried:
+* [GNU make中文手册](https://github.com/Jing--Li/book/blob/master/PL%20GNU%20make%20%E4%B8%AD%E6%96%87%E6%89%8B%E5%86%8C.pdf) (PDF)
 * [GNU make 指南](http://docs.huihoo.com/gnu/linux/gmake.html)
 * [Google C++ 风格指南](https://zh-google-styleguide.readthedocs.io/en/latest/google-cpp-styleguide/contents.html)
 * [C/C++ Primer](https://github.com/andycai/cprimer) (by @andycai)
@@ -693,7 +693,7 @@
 * [深入理解PHP内核](https://github.com/reeze/tipi)
 * [PHP扩展开发及内核应用](http://www.walu.cc/phpbook/) :worried:
 * [Laravel5.1 中文文档](http://laravel-china.org/docs/5.1) :worried:
-* [Laravel 5.1 LTS 速查表](https://cs.phphub.org/) :worried:
+* [Laravel 5.1 LTS 速查表](https://learninglaravel.net/cheatsheet-chinese)
 * [Symfony2 Cookbook 中文版](http://wiki.jikexueyuan.com/project/symfony-cookbook/)(版本 2.7.0 LTS)
 * [Symfony2中文文档](https://symfony-docs-chs.readthedocs.io/en/latest/) (未译完)
 * [YiiBook几本Yii框架的在线教程](http://yiibook.com//doc) :worried:
@@ -704,7 +704,7 @@
 * [Composer 中文网](http://www.phpcomposer.com)
 * [Slim 中文文档](http://ww1.minimee.org/php/slim) :worried:
 * [Lumen 中文文档](https://learnku.com/docs/lumen/5.7/)
-* [PHPUnit 中文文档](https://phpunit.de/manual/current/zh_cn/installation.html) :worried:
+* [PHPUnit 中文文档](https://www.w3cschool.cn/phpunit5/)
 * [PHP-LeetCode](https://github.com/wuqinqiang/leetcode-php)
 * [ThinkPHP5.1完全开发手册](https://www.kancloud.cn/manual/thinkphp5_1)
 * [ThinkPHP3.2.3完全开发手册](https://www.kancloud.cn/manual/thinkphp)
@@ -733,7 +733,7 @@
 * [PEP8 Python代码风格规范](https://code.google.com/p/zhong-wiki/wiki/PEP8)
 * [Google Python 风格指南 中文版](https://zh-google-styleguide.readthedocs.io/en/latest/google-python-styleguide/)
 * [Python入门教程](http://liam0205.me/2013/11/02/Python-tutorial-zh_cn/) ([PDF](http://liam0205.me/attachment/Python/The_Python_Tutorial_zh-cn.pdf))
-* [笨办法学 Python](http://old.sebug.net/paper/books/LearnPythonTheHardWay/) ([PDF](http://liam0205.me/attachment/Python/PyHardWay/Learn_Python_The_Hard_Way_zh-cn.pdf) [EPUB](https://www.gitbook.com/download/epub/book/wizardforcel/lpthw)) :worried:
+* [笨办法学 Python](http://liam0205.me/attachment/Python/PyHardWay/Learn_Python_The_Hard_Way_zh-cn.pdf) ([EPUB](https://www.gitbook.com/download/epub/book/wizardforcel/lpthw))
 * [Python自然语言处理中文版](http://pan.baidu.com/s/1qW4pvnY) （感谢陈涛同学的翻译，也谢谢 [@shwley](https://github.com/shwley) 联系了作者） :worried:
 * [Python 绘图库 matplotlib 官方指南中文翻译](http://liam0205.me/2014/09/11/matplotlib-tutorial-zh-cn/)
 * [Scrapy 0.25 文档](https://scrapy-chs.readthedocs.io/zh_CN/latest/)


### PR DESCRIPTION
在 #897 标注的基础上，为 19 处失效链接逐一搜索并更换为可用备份（全部经 curl 验证 HTTP 200）：

**官方新址（去掉 `:worried:`）**
- jinbuguo 三处（LFS、Apache、PostgreSQL）：`works.` 子域失效，改指作者主站新路径
- MyBatis 中文文档：官方目录 `zh/` → `zh_CN/`
- Lumen 中文文档：laravel-china 迁至 LearnKu
- 马上着手开发 iOS：苹果官方归档站
- Discover Meteor：官方中文版书稿仓库
- Django 搭建个人博客教程：作者本人的 GitHub 仓库（教程已完结，去掉编写中）

**社区镜像（去掉 `:worried:`）**
- Nginx 教程 PDF、Selenium 教程 EPUB、GNU make PDF、Design-Pattern 复制仓库、Laravel 速查表、PHPUnit（W3Cschool 同译本）
- 笨办法学 Python：主链接换为行内已有的可用 PDF

**仅存 Wayback 快照（改指快照，保留 `:worried:`）**
- IBM developerWorks 两专栏（官方站已关闭）、Neo4j.tw（仅 2013 年快照为真实内容）
- stackoverflow 问题 38210 已删除，条目改指仓库自带的中文整理版